### PR TITLE
Reboot on wifi failure

### DIFF
--- a/1_LOOP.ino
+++ b/1_LOOP.ino
@@ -5,7 +5,7 @@ void loop()
   server.handleClient();
 
   // Prüfe WiFi status
-  if ((WiFi.status() != WL_CONNECTED) ||  (!WiFi.localIP().isSet()))
+  if (WiFi.status() != WL_CONNECTED)
   {
     DEBUG_MSG("*** SYSINFO: WLAN nicht verbunden: %s\n", WiFi.status());
     DEBUG_MSG("*** SYSINFO: WLAN IP %s\n", WiFi.localIP().toString().c_str());

--- a/1_LOOP.ino
+++ b/1_LOOP.ino
@@ -1,17 +1,24 @@
+unsigned long nextResetTime=0;
 void loop()
 {
   // Webserver (80)
   server.handleClient();
 
   // Prüfe WiFi status
-  if (WiFi.status() != WL_CONNECTED)
+  if ((WiFi.status() != WL_CONNECTED) ||  (!WiFi.localIP().isSet()))
   {
     DEBUG_MSG("*** SYSINFO: WLAN nicht verbunden: %s\n", WiFi.status());
     DEBUG_MSG("*** SYSINFO: WLAN IP %s\n", WiFi.localIP().toString().c_str());
+    if (nextResetTime==0) nextResetTime=millis()+30*60*1000;
     WiFi.mode(WIFI_STA);
     WiFi.begin();
+  } else {
+    nextResetTime=0;
   }
-
+  if ((millis() > nextResetTime) && (nextResetTime>0)) {
+    SPIFFS.end(); // unmount SPIFFS
+    ESP.restart();
+  }
   // Check mDNS
   if (startMDNS)
     MDNS.update();


### PR DESCRIPTION
Mein Spundomat verbindet sich nicht mehr mit dem Wifi, wenn der Repeater kurz weg ist (zB Reboot oder abstecken). Das Problem scheinen auch andere User zu haben.
Meine Lösung: Nach 30 minuten ein Restart.
Nicht schön, aber funktioniert.
